### PR TITLE
ci: remove dependencies caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,6 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v4
-        with:
-          key: ${{ runner.os }}-dependencies-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-dependencies-
-          path: node_modules
-
       - name: Cache lint results
         uses: actions/cache@v4
         with:
@@ -46,12 +37,7 @@ jobs:
             .stylelintcache
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: bun install --frozen-lockfile
-
-      - name: Run postinstall script
-        if: steps.cache.outputs.cache-hit == 'true'
-        run: bun run postinstall
 
       - name: Check unused files, dependencies, and exports
         run: bun run check:unused

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,8 @@ jobs:
           node-version: lts/*
           registry-url: https://registry.npmjs.org
 
-      - name: Restore dependencies cache
-        uses: actions/cache/restore@v4
-        with:
-          key: ${{ runner.os }}-dependencies-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-dependencies-
-          path: node_modules
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Build
         run: bun run build

--- a/packages/create-app/template/.github/workflows/ci.yml
+++ b/packages/create-app/template/.github/workflows/ci.yml
@@ -28,15 +28,6 @@ jobs:
         with:
           node-version: lts/*
 
-      - name: Cache dependencies
-        id: cache
-        uses: actions/cache@v4
-        with:
-          key: ${{ runner.os }}-dependencies-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-dependencies-
-          path: node_modules
-
       - name: Cache lint results
         uses: actions/cache@v4
         with:
@@ -46,7 +37,6 @@ jobs:
             .stylelintcache
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
         run: bun install --frozen-lockfile
 
       - name: Check unused files, dependencies, and exports


### PR DESCRIPTION
`bun install` being so fast, caching dependencies seems overkill (`~2-3s` diff)