### PR TITLE
ci: use bun & node versions from package.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.0
+          bun-version-file: package.json
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version-file: package.json
 
       - name: Cache lint results
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.0
+          bun-version-file: package.json
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version-file: package.json
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -3,10 +3,13 @@
   "type": "module",
   "version": "0.7.0",
   "private": true,
+  "packageManager": "bun@1.2.0",
+  "engines": {
+    "node": "lts/*"
+  },
   "workspaces": [
     "packages/*"
   ],
-  "packageManager": "bun@1.2.0",
   "scripts": {
     "build": "bun --filter './packages/*' build",
     "clean": "del packages/*/dist",

--- a/packages/create-app/template/.github/workflows/ci.yml
+++ b/packages/create-app/template/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.1.43
+          bun-version-file: package.json
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version-file: package.json
 
       - name: Cache lint results
         uses: actions/cache@v4

--- a/packages/create-app/template/package.json
+++ b/packages/create-app/template/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.1",
   "private": true,
   "packageManager": "bun@1.2.0",
+  "engines": {
+    "node": "lts/*"
+  },
   "workspaces": [
     "backend",
     "frontend"


### PR DESCRIPTION
Use `package.json` as source of truth for `Bun` & `Node` versions.